### PR TITLE
Only allow Director Alias with get requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Director::Configuration.constraints.target_path.except = %r{\A/admin/}
 
 ### Request
 The request constraint yields the request itself to a given proc. This can be used to ignore asset requests or only
-apply aliasing based on any aspect of the request, for example, params, host name, etc.
+apply aliasing based on any aspect of the request, for example, params, host name, etc.<sup id="footnote_ref_1">[1](#footnote_1)</sup>
+
 ```ruby
 Director::Configuration.constraints.request.only = ->(request) { request.params['my_param'] == 'false' }
 # or
@@ -133,3 +134,6 @@ Director::Middleware.handled_request?(request) # => Boolean indicating whether o
 ### 1.1.x to 1.2.0
 
 Alias resolution is now case insensitive. All incoming paths are downcased before saving or resolving. If you have existing aliases, you should call `#save` on each one to trigger the path sanitizer which will downcase the saved paths so the the downcased paths coming in to the `#resolve` method.
+
+## Footnotes
+<span id="footnote_1">1.</span> By default, Director only handles GET and HEAD requests because the `redirect` handler cannot tell the browser to redirect a POST. The `proxy` handler could internally redirect a POST to an aliased target path, but this dichotomy adds too much complexity for it to be enabled out of the box. The constraints configuration gives you full control over which requests are handled by Director in your application. [↩](#footnote_ref_1)

--- a/lib/director/configuration.rb
+++ b/lib/director/configuration.rb
@@ -10,7 +10,7 @@ module Director
     @@constraints = OpenStruct.new({
       source_path: Constraint.new,
       target_path: Constraint.new,
-      request: Constraint.new(only: ->(request) { request.get? || request.head? }),
+      request: Constraint.new(->(request) { request.get? || request.head? }),
       format: Constraint.new,
       lookup_scope: ->(request) { {} }
     })

--- a/lib/director/configuration.rb
+++ b/lib/director/configuration.rb
@@ -10,7 +10,7 @@ module Director
     @@constraints = OpenStruct.new({
       source_path: Constraint.new,
       target_path: Constraint.new,
-      request: Constraint.new,
+      request: Constraint.new(only: ->(request) { request.get? || request.head? }),
       format: Constraint.new,
       lookup_scope: ->(request) { {} }
     })

--- a/spec/lib/middleware_spec.rb
+++ b/spec/lib/middleware_spec.rb
@@ -26,6 +26,41 @@ describe Director::Middleware do
       mock_request.get 'http://www.test.com/some/path'
       expect(Director::Middleware.handled_request?(request)).to be_falsey
     end
+
+    it 'returns true if get request' do
+      mock_request.get 'http://www.test.com/some/path'
+      expect(Director::Middleware.handled_request?(request)).to be_truthy
+    end
+
+    it 'returns true if head request' do
+      mock_request.head 'http://www.test.com/some/path'
+      expect(Director::Middleware.handled_request?(request)).to be_truthy
+    end
+
+    it 'returns false if post request' do
+      mock_request.post 'http://www.test.com/some/path'
+      expect(Director::Middleware.handled_request?(request)).to be_falsey
+    end
+
+    it 'returns false if patch request' do
+      mock_request.patch 'http://www.test.com/some/path'
+      expect(Director::Middleware.handled_request?(request)).to be_falsey
+    end
+
+    it 'returns false if delete request' do
+      mock_request.delete 'http://www.test.com/some/path'
+      expect(Director::Middleware.handled_request?(request)).to be_falsey
+    end
+
+    context 'request constraints reconfigured' do
+      before { allow(Director::Configuration.constraints.request).to receive(:only).and_return constraint }
+      let(:constraint) { ->(request) { request.post? } }
+
+      it 'returns true if constraint allows request' do
+        mock_request.post 'http://www.test.com/some/path'
+        expect(Director::Middleware.handled_request?(request)).to be_truthy
+      end
+    end
   end
 
   shared_examples_for 'a pass-through middleware' do |request_path|

--- a/spec/lib/middleware_spec.rb
+++ b/spec/lib/middleware_spec.rb
@@ -15,38 +15,43 @@ describe Director::Middleware do
   end
 
   describe '::handled_request?' do
-    it 'returns true if get request' do
+    it 'returns true if GET request' do
       mock_request.get 'http://www.test.com/some/path'
       expect(Director::Middleware.handled_request?(request)).to be_truthy
     end
 
-    it 'returns true if head request' do
+    it 'returns true if HEAD request' do
       mock_request.head 'http://www.test.com/some/path'
       expect(Director::Middleware.handled_request?(request)).to be_truthy
     end
 
-    it 'returns false if post request' do
+    it 'returns false if POST request' do
       mock_request.post 'http://www.test.com/some/path'
       expect(Director::Middleware.handled_request?(request)).to be_falsey
     end
 
-    it 'returns false if patch request' do
+    it 'returns false if PATCH request' do
       mock_request.patch 'http://www.test.com/some/path'
       expect(Director::Middleware.handled_request?(request)).to be_falsey
     end
 
-    it 'returns false if delete request' do
+    it 'returns false if DELETE request' do
       mock_request.delete 'http://www.test.com/some/path'
       expect(Director::Middleware.handled_request?(request)).to be_falsey
     end
 
-    context 'request constraints reconfigured' do
+    context 'when the request constraint is reconfigured' do
       before { allow(Director::Configuration.constraints.request).to receive(:only).and_return constraint }
       let(:constraint) { ->(request) { request.post? } }
 
-      it 'returns true if constraint allows request' do
+      it 'returns true if the constraint allows request' do
         mock_request.post 'http://www.test.com/some/path'
         expect(Director::Middleware.handled_request?(request)).to be_truthy
+      end
+
+      it 'returns false if the constraint does not allow request' do
+        mock_request.get 'http://www.test.com/some/path'
+        expect(Director::Middleware.handled_request?(request)).to be_falsey
       end
     end
   end

--- a/spec/lib/middleware_spec.rb
+++ b/spec/lib/middleware_spec.rb
@@ -15,41 +15,41 @@ describe Director::Middleware do
   end
 
   describe '::handled_request?' do
-    it 'returns true if GET request' do
+    it 'returns true if the request is a GET' do
       mock_request.get 'http://www.test.com/some/path'
       expect(Director::Middleware.handled_request?(request)).to be_truthy
     end
 
-    it 'returns true if HEAD request' do
+    it 'returns true if the request is a HEAD' do
       mock_request.head 'http://www.test.com/some/path'
       expect(Director::Middleware.handled_request?(request)).to be_truthy
     end
 
-    it 'returns false if POST request' do
+    it 'returns false if the request is a POST' do
       mock_request.post 'http://www.test.com/some/path'
       expect(Director::Middleware.handled_request?(request)).to be_falsey
     end
 
-    it 'returns false if PATCH request' do
+    it 'returns false if the request is a PATCH' do
       mock_request.patch 'http://www.test.com/some/path'
       expect(Director::Middleware.handled_request?(request)).to be_falsey
     end
 
-    it 'returns false if DELETE request' do
+    it 'returns false if the request is a DELETE' do
       mock_request.delete 'http://www.test.com/some/path'
       expect(Director::Middleware.handled_request?(request)).to be_falsey
     end
 
-    context 'when the request constraint is reconfigured' do
+    context 'when the default request constraint is reconfigured' do
       before { allow(Director::Configuration.constraints.request).to receive(:only).and_return constraint }
       let(:constraint) { ->(request) { request.post? } }
 
-      it 'returns true if the constraint allows request' do
+      it 'returns true if the constraint allows the request' do
         mock_request.post 'http://www.test.com/some/path'
         expect(Director::Middleware.handled_request?(request)).to be_truthy
       end
 
-      it 'returns false if the constraint does not allow request' do
+      it 'returns false if the constraint does not allow the request' do
         mock_request.get 'http://www.test.com/some/path'
         expect(Director::Middleware.handled_request?(request)).to be_falsey
       end

--- a/spec/lib/middleware_spec.rb
+++ b/spec/lib/middleware_spec.rb
@@ -15,18 +15,6 @@ describe Director::Middleware do
   end
 
   describe '::handled_request?' do
-    it 'returns true if the request was not ignored' do
-      expect(middleware).to receive(:ignored?).and_return(false)
-      mock_request.get 'http://www.test.com/some/path'
-      expect(Director::Middleware.handled_request?(request)).to be_truthy
-    end
-
-    it 'returns true if the request was ignored' do
-      expect(middleware).to receive(:ignored?).and_return(true)
-      mock_request.get 'http://www.test.com/some/path'
-      expect(Director::Middleware.handled_request?(request)).to be_falsey
-    end
-
     it 'returns true if get request' do
       mock_request.get 'http://www.test.com/some/path'
       expect(Director::Middleware.handled_request?(request)).to be_truthy


### PR DESCRIPTION
- we cannot post to a redirect. This will never work. 
- Prevent Director from trying to handle any requests other than get.